### PR TITLE
Bump version to 1.0.6

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "1.0.5"
+current_version = "1.0.6"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)"
 serialize = ["{major}.{minor}.{patch}"]
 search = "{current_version}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.6] - 2025-08-29
+
 ### Added
 
-* Added post-review-release option.
+- Added post-review-release option.
 
 ## [1.0.5] - 2025-08-29
 
@@ -43,7 +45,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - More dummy changes.
 
-[Unreleased]: https://github.com/daniel-jones-dev/bumpversion-test/compare/v1.0.5...HEAD
+[Unreleased]: https://github.com/daniel-jones-dev/bumpversion-test/compare/v1.0.6...HEAD
+
+[1.0.6]: https://github.com/daniel-jones-dev/bumpversion-test/compare/v1.0.5...v1.0.6
 
 [1.0.5]: https://github.com/daniel-jones-dev/bumpversion-test/compare/v1.0.4...v1.0.5
 

--- a/src/a.py
+++ b/src/a.py
@@ -7,4 +7,4 @@ def func_b():
     pass
 
 def current_version():
-    return "1.0.5"
+    return "1.0.6"

--- a/src/b.py
+++ b/src/b.py
@@ -7,9 +7,9 @@ def func_b():
     pass
 
 def current_version_a():
-    return "1.0.5"
+    return "1.0.6"
 
 
 def current_version_with_extra():
-    return "1.0.5" + "-extra"
+    return "1.0.6" + "-extra"
 


### PR DESCRIPTION
This PR bumps the version to 1.0.6 and updates the changelog.
After merging this PR, remember to re-trigger this action with the 'post-review-release' option to create the tag & release.